### PR TITLE
Pin links to FFmpeg-Builds release

### DIFF
--- a/en/get-started/ffmpeg-install.md
+++ b/en/get-started/ffmpeg-install.md
@@ -12,7 +12,7 @@ https://www.ffmpeg.org/legal.html
 
 ### For Windows (64bit)
 Download `ffmpeg-n6.0-latest-win64-gpl-shared-6.0.zip` from the following page:  
-https://github.com/BtbN/FFmpeg-Builds/releases
+[Release Auto-Build 2023-11-30 12:55 · BtbN/FFmpeg-Builds](https://github.com/BtbN/FFmpeg-Builds/releases/tag/autobuild-2023-11-30-12-55)
 
 Extract the downloaded file and place the files from `ffmpeg-n6.0-latest-win64-gpl-shared-6.0\bin\` as follows:
 
@@ -35,7 +35,7 @@ C:\Users\(your_username)\.beutl\ffmpeg
 **FFmpeg installed via package manager may not work correctly due to version differences. Therefore, follow the same steps as for Windows.**
 
 Download `ffmpeg-n6.0-latest-linux64-gpl-shared-6.0.tar.xz` from the following page:  
-https://github.com/BtbN/FFmpeg-Builds/releases
+[Release Auto-Build 2023-11-30 12:55 · BtbN/FFmpeg-Builds](https://github.com/BtbN/FFmpeg-Builds/releases/tag/autobuild-2023-11-30-12-55)
 
 Extract the downloaded file and place the files from `bin/` and `lib/` as follows:
 

--- a/ja/get-started/ffmpeg-install.md
+++ b/ja/get-started/ffmpeg-install.md
@@ -12,7 +12,7 @@ https://www.ffmpeg.org/legal.html
 
 ### Windows (64bit) の場合
 以下のページから、`ffmpeg-n6.0-latest-win64-gpl-shared-6.0.zip`をダウンロードします。  
-https://github.com/BtbN/FFmpeg-Builds/releases
+[Release Auto-Build 2023-11-30 12:55 · BtbN/FFmpeg-Builds](https://github.com/BtbN/FFmpeg-Builds/releases/tag/autobuild-2023-11-30-12-55)
 
 ダウンロードしたファイルを展開して、
 `ffmpeg-n6.0-latest-win64-gpl-shared-6.0\bin\`内のファイルを以下のように配置します。
@@ -37,7 +37,7 @@ C:\Users\(ユーザー)\.beutl\ffmpeg
 なので、Windowsと同様に操作を行ってください。**
 
 以下のページから、`ffmpeg-n6.0-latest-linux64-gpl-shared-6.0.tar.xz`をダウンロードします。  
-https://github.com/BtbN/FFmpeg-Builds/releases
+[Release Auto-Build 2023-11-30 12:55 · BtbN/FFmpeg-Builds](https://github.com/BtbN/FFmpeg-Builds/releases/tag/autobuild-2023-11-30-12-55)
 
 ダウンロードしたファイルを展開して、
 `bin/`および`lib/`内のファイルを以下のように配置します。


### PR DESCRIPTION
The v6.0 build of ffmpeg is not in the latest release and is difficult to find.
In this PR, I have pinned the download link to the following release, which is the last release that had a v6.0 build.

[Release Auto-Build 2023-11-30 12:55 · BtbN/FFmpeg-Builds](https://github.com/BtbN/FFmpeg-Builds/releases/tag/autobuild-2023-11-30-12-55)