### PR TITLE
Fix FFmpeg Configuration Tool Download Link

### DIFF
--- a/en/get-started/ffmpeg-install.md
+++ b/en/get-started/ffmpeg-install.md
@@ -86,9 +86,9 @@ Then, run the following command to install FFmpeg:
 brew install ffmpeg@6
 ```
 
-## Using the [FFmpeg Configuration Tool](https://beutl.beditor.net/store/packages/Beutl.Extensions.FFmpegLocator)
+## Using the [FFmpeg Configuration Tool](https://beutl.beditor.net/en/store/Beutl.Extensions.FFmpegLocator)
 
-From version `1.0.0-preview4` onwards, you can use the [FFmpeg Configuration Tool](https://beutl.beditor.net/store/packages/Beutl.Extensions.FFmpegLocator).
+From version `1.0.0-preview4` onwards, you can use the [FFmpeg Configuration Tool](https://beutl.beditor.net/en/store/Beutl.Extensions.FFmpegLocator).
 
 > [!TIP]
 > You need a Beutl account to use this method.  

--- a/ja/get-started/ffmpeg-install.md
+++ b/ja/get-started/ffmpeg-install.md
@@ -89,9 +89,9 @@ C:\Users\(ユーザー)\.beutl\ffmpeg
 brew install ffmpeg@6
 ```
 
-## [FFmpeg配置ツール](https://beutl.beditor.net/store/packages/Beutl.Extensions.FFmpegLocator)を使う
+## [FFmpeg配置ツール](https://beutl.beditor.net/ja/store/Beutl.Extensions.FFmpegLocator)を使う
 
-バージョン`1.0.0-preview4`以降は[FFmpeg配置ツール](https://beutl.beditor.net/store/packages/Beutl.Extensions.FFmpegLocator)を使うことができます。
+バージョン`1.0.0-preview4`以降は[FFmpeg配置ツール](https://beutl.beditor.net/ja/store/Beutl.Extensions.FFmpegLocator)を使うことができます。
 
 > [!TIP]
 > この方法を実行するにはBeutlアカウントが必要です。  


### PR DESCRIPTION
Fix #7 

FFMpeg配置ツールのリンクを
正しいストアページに書き換えました。